### PR TITLE
Add support for Android 12 (sdk 31)

### DIFF
--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -4,13 +4,13 @@ plugins {
 }
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
     buildToolsVersion "30.0.3"
 
     defaultConfig {
         applicationId "ramp.network.demo"
         minSdkVersion 24
-        targetSdkVersion 30
+        targetSdkVersion 31
         versionCode 2
         versionName "1.1"
 

--- a/demo/src/main/AndroidManifest.xml
+++ b/demo/src/main/AndroidManifest.xml
@@ -9,7 +9,8 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.RampSDK">
-        <activity android:name=".MainActivity">
+        <activity android:name=".MainActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/rampsdk/build.gradle
+++ b/rampsdk/build.gradle
@@ -15,13 +15,13 @@ repositories {
 }
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
     buildToolsVersion "30.0.3"
 
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 30
+        targetSdkVersion 31
         versionCode 6
         versionName "1.3.3"
 

--- a/rampsdk/src/main/AndroidManifest.xml
+++ b/rampsdk/src/main/AndroidManifest.xml
@@ -12,7 +12,8 @@
             android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|uiMode|screenSize|smallestScreenSize"
             android:launchMode="singleTask"
             android:theme="@style/RampInstant.NoActionBar"
-            android:windowSoftInputMode="adjustResize">
+            android:windowSoftInputMode="adjustResize"
+            android:exported="true">
 
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />


### PR DESCRIPTION
Currently, apps targeting sdk 31 cannot implement Ramp. When the manifests get merged, the build fails because Ramp's manifest does not include the "exported" element which is now required on all activities with intent-filters.

See: https://developer.android.com/guide/topics/manifest/activity-element#exported

I've added the exported element to the appropriate activity in both the demo and the sdk, and I've updated the target and compile versions to 31.

Looking forward to adding Ramp to our project!