### PR TITLE
OnPurchaseFailed deprecated. Removed label and supportsRtl parameters…

### DIFF
--- a/rampsdk/build.gradle
+++ b/rampsdk/build.gradle
@@ -22,8 +22,8 @@ android {
     defaultConfig {
         minSdkVersion 21
         targetSdkVersion 32
-        versionCode 16
-        versionName "3.0.0"
+        versionCode 17
+        versionName "3.0.1"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles 'consumer-rules.pro'
         buildConfigField 'String', 'VERSION',  "\"${defaultConfig.versionName}\""

--- a/rampsdk/src/main/AndroidManifest.xml
+++ b/rampsdk/src/main/AndroidManifest.xml
@@ -6,9 +6,7 @@
     <uses-feature android:name="android.hardware.camera" android:required="true"/>
 
     <application
-        android:label="@string/app_name"
-        android:launchMode="singleTask"
-        android:supportsRtl="true">
+        android:launchMode="singleTask">
         <activity
             android:name="network.ramp.sdk.ui.activity.RampWidgetActivity"
             android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|uiMode|screenSize|smallestScreenSize"

--- a/rampsdk/src/main/java/network/ramp/sdk/facade/RampCallback.kt
+++ b/rampsdk/src/main/java/network/ramp/sdk/facade/RampCallback.kt
@@ -6,6 +6,7 @@ import network.ramp.sdk.events.model.Asset
 
 interface RampCallback {
 
+    @Deprecated(message = "This method is deprecated and will be removed in future versions.")
     fun onPurchaseFailed()
 
     fun onPurchaseCreated(purchase: Purchase, purchaseViewToken: String, apiUrl: String)


### PR DESCRIPTION
- OnPurchaseFailed deprecated. 
- Removed label and supportsRtl parameters from library manifest.